### PR TITLE
Fix missing keys when value is bool false

### DIFF
--- a/variables/Snowplow Context.tpl
+++ b/variables/Snowplow Context.tpl
@@ -210,7 +210,7 @@ const context = {
 };
 
 schemaProperties.forEach(schemaProperty => {
-  	if(schemaProperty.fieldName.toString() && schemaProperty.fieldData.toString()) { 
+  	if(schemaProperty.fieldName && schemaProperty.fieldData + '' && schemaProperty.fieldData !== null) { 
     	context.data[schemaProperty.fieldName] = schemaProperty.fieldData;
     }
 });

--- a/variables/Snowplow Context.tpl
+++ b/variables/Snowplow Context.tpl
@@ -210,7 +210,7 @@ const context = {
 };
 
 schemaProperties.forEach(schemaProperty => {
-  	if(schemaProperty.fieldName && schemaProperty.fieldData) { 
+  	if(schemaProperty.fieldName.toString() && schemaProperty.fieldData.toString()) { 
     	context.data[schemaProperty.fieldName] = schemaProperty.fieldData;
     }
 });


### PR DESCRIPTION
When the fieldData contains a boolean false, the if statement fails and excludes the field from the final list. Casting the values to string should fix this.